### PR TITLE
flake: use nixpkgs.lib for lib output

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,6 +88,21 @@
         "type": "github"
       }
     },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1620519687,
+        "narHash": "sha256-+6Dd72b2CASuXm2W7KRxZIE7AOy/dj4mU28vaF+zxcs=",
+        "owner": "divnix",
+        "repo": "nixpkgs.lib",
+        "rev": "c7b6169809c5f74dd0c34f3d69e9d12ba4d448de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1610942247,
@@ -106,22 +121,24 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1619244632,
-        "narHash": "sha256-IDcbMRnyKO9WlQ5xzIlM3HfWAUKTy+3xSd+CvDGiLgE=",
-        "owner": "NixOS",
+        "lastModified": 1620962350,
+        "narHash": "sha256-9ASW4d4/Z8HmRvuJI8rxbEOTbXTBpQ8y+CmFYBwtXzE=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5cecebfb2f76da7b93f19967e99b3ff4fb4d2850",
+        "rev": "5d4a430472cafada97888cc80672fab255231f57",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
         "deploy": "deploy",
         "devshell": "devshell",
+        "nixlib": "nixlib",
         "nixpkgs": "nixpkgs_2",
         "utils": "utils_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,12 +6,16 @@
       deploy.url = "github:serokell/deploy-rs";
       devshell.url = "github:numtide/devshell";
       utils.url = "github:gytis-ivaskevicius/flake-utils-plus/staging";
+      nixlib.url = "github:divnix/nixpkgs.lib";
+
+      # Only used for development
+      nixpkgs.url = "github:nixos/nixpkgs";
     };
 
-  outputs = inputs@{ self, nixpkgs, deploy, devshell, utils, ... }:
+  outputs = inputs@{ self, nixlib, nixpkgs, deploy, devshell, utils, ... }:
     let
-      lib = nixpkgs.lib.makeExtensible (self:
-        let combinedLib = nixpkgs.lib // self; in
+      lib = nixlib.lib.makeExtensible (self:
+        let combinedLib = nixlib.lib // self; in
         with self;
         utils.lib // {
           attrs = import ./src/attrs.nix { lib = combinedLib; };
@@ -65,7 +69,7 @@
         checks = {
           tests = import ./tests {
             inherit pkgs;
-            lib = nixpkgs.lib // lib;
+            lib = nixlib.lib // lib;
           };
         };
 


### PR DESCRIPTION
Based on my understanding of NixOS/nix#2920, this would improve things. Since devos and anyone else using devlib usually only make use of the `lib` output, this would decrease download costs. Only the other outputs actually make use of `nixpkgs`, so nixpkgs shouldn't be pulled as a dependency from this library if only `devlib.lib` is used.
On a side note: I think lazy-fetching of inputs is a pretty good solution to the "development dependencies" issue.