### PR TITLE
importers: dedicated importers for api arguments

### DIFF
--- a/src/importers.nix
+++ b/src/importers.nix
@@ -43,17 +43,23 @@ let
     in
     lib.mapAttrs f imports;
 
-in
-{
-  inherit recImport mkProfileAttrs;
-
   pathsIn = dir:
     let
       fullPath = name: "${toString dir}/${name}";
     in
     map fullPath (lib.attrNames (lib.safeReadDir dir));
 
-  importHosts = dir:
+in
+{
+  inherit pathsIn recImport mkProfileAttrs;
+
+  overlays = dir:
+    {
+      # Meant to output a module that sets the overlays option
+      overlays = pathsIn dir;
+    };
+
+  hosts = dir:
     {
       # Meant to output a module that sets the hosts option
       hosts = recImport {

--- a/src/mkFlake/evalArgs.nix
+++ b/src/mkFlake/evalArgs.nix
@@ -230,7 +230,9 @@ let
           '';
         };
         channels = mkOption {
-          type = attrsOf (submodule channelsModule);
+          type = attrsOf (submoduleWith {
+            modules = [ channelsModule ];
+          });
           default = { };
           description = ''
             nixpkgs channels to create


### PR DESCRIPTION
This allows `importers.hosts` and `importers.overlays` to be used specifically for those api arguments.

What the goal is for devos's flake.nix:
```
channels.nixos = {
  imports = [ (importers.overlays ./overlays) ];
  overlays = [ ];
};
nixos = {
  imports = [ (importers.hosts ./hosts) ];
  hosts = { };
};
```