### PR TITLE
add devshellModules option to customize devshell

### DIFF
--- a/src/mkFlake/default.nix
+++ b/src/mkFlake/default.nix
@@ -96,6 +96,7 @@ lib.systemFlake (lib.mergeAny
     devShellBuilder = channels:
       lib.pkgs-lib.shell {
         pkgs = getDefaultChannel channels;
+        extraModules = cfg.devshellModules;
       };
   }
   otherArguments # for overlays list order

--- a/src/mkFlake/evalArgs.nix
+++ b/src/mkFlake/evalArgs.nix
@@ -43,6 +43,16 @@ let
       coercedListOf = elemType: with types;
         coercedTo anything (x: flatten (singleton x)) (listOf elemType);
 
+      pathToDevshellModule = with types; (coercedTo path (path:
+        let pathstr = toString path; in
+        if lib.hasSuffix ".toml" pathstr then
+          { pkgs, ... }: { imports = [ (pkgs.devshell.importTOML path) ]; }
+        else
+          import path
+      ) moduleType) // {
+        description = "path to a devshell module(including .toml files)";
+      };
+
       /* Submodules needed for API containers */
 
       channelsModule = { name, ... }: {
@@ -260,6 +270,13 @@ let
           default = { };
           description = ''
             hosts, modules, suites, and profiles for home-manager
+          '';
+        };
+        devshellModules = mkOption {
+          type = coercedListOf pathToDevshellModule;
+          default = [ ];
+          description = ''
+            devshell modules(including .toml files) to add to the devshell
           '';
         };
       };

--- a/src/pkgs-lib/shell/default.nix
+++ b/src/pkgs-lib/shell/default.nix
@@ -1,6 +1,6 @@
 { lib, devshell, deploy }:
 
-{ pkgs }:
+{ pkgs, extraModules ? [ ] }:
 let
   overlays = [
     devshell.overlay
@@ -34,34 +34,40 @@ let
   };
   customPackages = lib.builder.packagesFromOverlaysBuilderConstructor allOverlays { pkgs = pkgs'; };
 
+  configuration = {
+    imports = [ (pkgs'.devshell.importTOML ./devshell.toml) ] ++ extraModules;
+
+    packages = with installPkgs; [
+      nixos-install
+      nixos-generate-config
+      nixos-enter
+    ] ++ (builtins.attrValues customPackages);
+
+    git.hooks = {
+      pre-commit.text = lib.fileContents ./pre-commit.sh;
+    };
+
+    commands = with pkgs'; [
+      { package = flk; }
+      {
+        name = "nix";
+        help = pkgs'.nixFlakes.meta.description;
+        command = ''
+          ${pkgs'.nixFlakes}/bin/nix --experimental-features "nix-command flakes ca-references" "${"\${@}"}"
+        '';
+      }
+    ]
+    ++ lib.optional (system != "i686-linux") { package = cachix; }
+    ++ lib.optional (system == "x86_64-linux") {
+      name = "deploy";
+      package = deploy-rs;
+      help = "A simple multi-profile Nix-flake deploy tool.";
+    };
+  };
 in
-pkgs'.devshell.mkShell {
-  imports = [ (pkgs'.devshell.importTOML ./devshell.toml) ];
-
-  packages = with installPkgs; [
-    nixos-install
-    nixos-generate-config
-    nixos-enter
-  ] ++ (builtins.attrValues customPackages);
-
-  git.hooks = {
-    pre-commit.text = lib.fileContents ./pre-commit.sh;
-  };
-
-  commands = with pkgs'; [
-    { package = flk; }
-    {
-      name = "nix";
-      help = pkgs'.nixFlakes.meta.description;
-      command = ''
-        ${pkgs'.nixFlakes}/bin/nix --experimental-features "nix-command flakes ca-references" "${"\${@}"}"
-      '';
-    }
-  ]
-  ++ lib.optional (system != "i686-linux") { package = cachix; }
-  ++ lib.optional (system == "x86_64-linux") {
-    name = "deploy";
-    package = deploy-rs;
-    help = "A simple multi-profile Nix-flake deploy tool.";
-  };
-}
+(pkgs'.devshell.eval {
+  inherit configuration;
+  # Allows us to use devshell's `importTOML` within a module
+  # used in evalArgs to auto-import toml files
+  extraSpecialArgs.pkgs = pkgs';
+}).shell


### PR DESCRIPTION
Adds `devshellModules` api argument to add modules to the devshell. This also accepts `.toml` files which get auto-imported with devshell's `devshell.importToml`. To get that to work we have to pass `pkgs` as a specialArg so it can be used in an `imports` line.