### PR TITLE
shell: append overlays

### DIFF
--- a/src/pkgs-lib/shell/default.nix
+++ b/src/pkgs-lib/shell/default.nix
@@ -17,10 +17,7 @@ let
     })
   ];
 
-  pkgs' = import pkgs.path {
-    inherit (pkgs) system;
-    inherit overlays;
-  };
+  pkgs' = pkgs.appendOverlays overlays;
 
   flk = pkgs'.callPackage ./flk.nix { };
 


### PR DESCRIPTION
fixes #21 
Makes it so the overlays of the default channel are included in the devshell - not installed, but available in modules