### PR TITLE
Shell: setup export of devshell modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "devshell": {
       "locked": {
-        "lastModified": 1618523768,
-        "narHash": "sha256-Gev9da35pHUey3kGz/zrJFc/9ICs++vPCho7qB1mqd8=",
+        "lastModified": 1622013274,
+        "narHash": "sha256-mK/Lv0lCbl07dI5s7tR/7nb79HunKnJik3KyR6yeI2k=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "709fe4d04a9101c9d224ad83f73416dce71baf21",
+        "rev": "e7faf69e6bf8546517cc936c7f6d31c7eb3abcb2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,11 @@
           lists = import ./src/lists.nix { lib = combinedLib; };
           strings = import ./src/strings.nix { lib = combinedLib; };
           modules = import ./src/modules.nix { lib = combinedLib; };
-          importers = import ./src/importers.nix { lib = combinedLib; };
+
+          importers = import ./src/importers.nix {
+            lib = combinedLib;
+            inherit devshell;
+          };
 
           generators = import ./src/generators.nix {
             lib = combinedLib;
@@ -42,7 +46,7 @@
           inherit (attrs) mapFilterAttrs genAttrs' safeReadDir concatAttrs;
           inherit (lists) unifyOverlays;
           inherit (strings) rgxToString;
-          inherit (importers) profileMap rakeLeaves;
+          inherit (importers) profileMap rakeLeaves maybeImportDevshellModule;
           inherit (generators) mkSuites mkDeployNodes mkHomeConfigurations;
         }
       );

--- a/src/importers.nix
+++ b/src/importers.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, devshell }:
 let
   rakeLeaves =
     /**
@@ -80,5 +80,14 @@ in
         })
         (rakeLeaves dir);
     };
+
+  maybeImportDevshellModule = item:
+    let isPath = builtins.isPath item || builtins.isString item; in
+    if isPath && lib.hasSuffix ".toml" item then
+      devshell.lib.importTOML item
+    else if isPath && lib.hasSuffix ".nix" then
+      import item
+    else item;
+
 }
 

--- a/src/mkFlake/default.nix
+++ b/src/mkFlake/default.nix
@@ -75,6 +75,11 @@ lib.systemFlake (lib.mergeAny
 
     homeModules = lib.exporters.modulesFromList cfg.home.modules;
 
+    devshellModules = lib.exporters.modulesFromList {
+      paths = cfg.devshell.modules;
+      _import = lib.maybeImportDevshellModule;
+    };
+
     overlays = lib.exporters.internalOverlays {
       # since we can't detect overlays owned by self
       # we have to filter out ones exported by the inputs
@@ -100,7 +105,7 @@ lib.systemFlake (lib.mergeAny
 
           devShell = lib.pkgs-lib.shell {
             pkgs = defaultChannel;
-            extraModules = cfg.devshellModules;
+            extraModules = cfg.devshell.modules ++ cfg.devshell.externalModules;
           };
         }
         (cfg.outputsBuilder channels);

--- a/src/pkgs-lib/shell/default.nix
+++ b/src/pkgs-lib/shell/default.nix
@@ -26,8 +26,10 @@ let
     modules = [ ];
   }).config.system.build;
 
+
   configuration = {
-    imports = [ (pkgs'.devshell.importTOML ./devshell.toml) ] ++ extraModules;
+    imports = [ (pkgs'.devshell.importTOML ./devshell.toml) ]
+      ++ (map lib.maybeImportDevshellModule extraModules);
 
     packages = with installPkgs; [
       nixos-install
@@ -58,9 +60,4 @@ let
     ++ lib.optional (system != "i686-linux") { package = cachix; };
   };
 in
-(pkgs'.devshell.eval {
-  inherit configuration;
-  # Allows us to use devshell's `importTOML` within a module
-  # used in evalArgs to auto-import toml files
-  extraSpecialArgs.pkgs = pkgs';
-}).shell
+pkgs'.devshell.mkShell configuration

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -41,4 +41,5 @@ in
 
   checksTest = mkOutputTest "checks";
 
+  devShellTest = fullFlake.devShell.${pkgs.system};
 }

--- a/tests/fullFlake/default.nix
+++ b/tests/fullFlake/default.nix
@@ -34,6 +34,8 @@ let
       })
     ];
 
+    devshell.modules = [ ./devshell.toml ];
+
     nixos = {
       hostDefaults = {
         system = "x86_64-linux";

--- a/tests/fullFlake/devshell.toml
+++ b/tests/fullFlake/devshell.toml
@@ -1,0 +1,5 @@
+[devshell]
+
+packages = [
+  "mdbook",
+]


### PR DESCRIPTION
Introduces `devshell` namespace for `modules` and `externalModules`.

the import of .toml files no longer happens in evalArgs but instead happens as devshell modules are being exported and imported into shell.

depends on numtide/devshell#117