### PR TITLE
imp: make importers truely recursive

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         "flake-utils": "flake-utils"
       },
       "locked": {
-        "lastModified": 1621608968,
-        "narHash": "sha256-VN9Zr6xY2gkBxIR538UVzuTECTMaDFds5qgaucZrDIc=",
+        "lastModified": 1622483093,
+        "narHash": "sha256-OsT4fKqgM4gcNAsGwf7E7c4iclAvqoFlMe1tslowRBw=",
         "owner": "gytis-ivaskevicius",
         "repo": "flake-utils-plus",
-        "rev": "3929c2b70c3b4bb7bacd7f064e4f23f47981654a",
+        "rev": "7f2371107b82c7c08558f59e0d25b65000f64a99",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
           inherit (attrs) mapFilterAttrs genAttrs' concatAttrs;
           inherit (lists) unifyOverlays;
           inherit (strings) rgxToString;
-          inherit (importers) profileMap rakeLeaves mkProfileAttrs maybeImportDevshellModule;
+          inherit (importers) profileMap flattenTree rakeLeaves mkProfileAttrs maybeImportDevshellModule;
           inherit (generators) mkSuites mkDeployNodes mkHomeConfigurations;
         }
       );

--- a/tests/fullFlake/default.nix
+++ b/tests/fullFlake/default.nix
@@ -24,7 +24,8 @@ let
 
     outputsBuilder = channels: {
       checks = {
-        hostBuild = self.nixosConfigurations.NixOS.config.system.build.toplevel;
+        hostBuild = assert self.nixosConfigurations ? "com.example.myhost";
+          self.nixosConfigurations.NixOS.config.system.build.toplevel;
       };
     };
 

--- a/tests/fullFlake/hosts/com/example/myhost/default.nix
+++ b/tests/fullFlake/hosts/com/example/myhost/default.nix
@@ -1,0 +1,12 @@
+{ suites, ... }:
+{
+  ### root password is empty by default ###
+  imports = suites.base;
+
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  networking.networkmanager.enable = true;
+
+  fileSystems."/" = { device = "/dev/disk/by-label/nixos"; };
+}

--- a/tests/lib/default.nix
+++ b/tests/lib/default.nix
@@ -44,4 +44,13 @@ lib.runTests {
       };
     };
   };
+
+  testFlattenTree = {
+    expr = importers.flattenTree (importers.rakeLeaves ./profiles);
+    expected  = {
+      f = ./profiles/f.nix;
+      foo = ./profiles/foo;
+      "t.bar" = ./profiles/t/bar.nix;
+    };
+  };
 }


### PR DESCRIPTION
- hostnames are construed from a reverse DNS notation of folder names

BREAKING CHANGE (without practical impact):

fup needs to be udpated to parse the reverse DNS notation back into
a hostname DNS label + a DNS domain (to set networking.domain).

However, since until now, no recursive hosts where allowed, this
can be safely done soonishly.