### PR TITLE
fix: flk usage of lock update

### DIFF
--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -52,11 +52,11 @@ case "$1" in
   "update")
     if [[ -n "$2" ]]; then
       if [[ -n "$3" ]]; then
-        (cd $2; nix flake list-inputs --update-input "$3")
+        (cd $2; nix flake lock --update-input "$3")
       else
         (cd $2; nix flake update)
       fi
-      nix flake list-inputs --update-input "$2" "$DEVSHELL_ROOT"
+      nix flake lock --update-input "$2" "$DEVSHELL_ROOT"
     else
       nix flake update "$DEVSHELL_ROOT"
     fi


### PR DESCRIPTION
After discussion with @Pacman99 
the used command did not update as intended in one instance locally on my machine.

I din't investigate further, but `nix flake lock` seems the correct way to to this.