### PR TITLE
importers: filter out empty attrsets

### DIFF
--- a/src/importers.nix
+++ b/src/importers.nix
@@ -48,7 +48,7 @@ let
         # builtins.trace "${toString path} is something else"
           sum
       ;
-    
+
       recurse = sum: path: val:
         builtins.foldl'
           (sum: key: op sum (path ++ [ key ]) val.${key})
@@ -108,8 +108,10 @@ let
             # recurse on directories that don't contain a `default.nix`
             else rakeLeaves path;
       };
+
+      files = lib.filterAttrs seive (builtins.readDir dirPath);
     in
-    lib.mapAttrs' collect (lib.filterAttrs seive (builtins.readDir dirPath));
+    lib.filterAttrs (n: v: v != { }) (lib.mapAttrs' collect files);
 
   # DEPRECATED, prefer rakeLeaves
   mkProfileAttrs =


### PR DESCRIPTION
Allows you to have arbitrary folders that only get picked up if .nix files are in there. This could be useful for a folder dedicated to contains patches. And generally improves safety of the now fully recursive importers.

I decided to put this in rakeLeaves, since it makes no sense to rake pointless folders and the change propagates to all importers.