### PR TITLE
Added vm and vm-run commands to flk.sh

### DIFF
--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -100,6 +100,7 @@ case "$1" in
         && "$DEVSHELL_ROOT/vm/tmp/$3/bin/run-$3-vm" \
       ) \
       && rm -rf "$DEVSHELL_ROOT/vm/tmp/$3"* \
+      && rmdir --ignore-fail-on-non-empty "$DEVSHELL_ROOT/vm/tmp"
     else
       nix build \
         "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.vm" \

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -102,6 +102,8 @@ case "$1" in
       "$DEVSHELL_ROOT/vm/$2" \
       "${@:3}" \
       && \
+      rm -f "$DEVSHELL_ROOT/vm/$2.qcow2" \
+      && \
       (export NIX_DISK_IMAGE="$DEVSHELL_ROOT/vm/$2.qcow2" \
       && \
       "$DEVSHELL_ROOT/vm/$2/bin/run-$2-vm" \

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -21,6 +21,8 @@ usage () {
   "get (core|community) [DEST]" "Copy the desired template to DEST" \
   "doi HOST" "Generate DigitalOcean image of HOST" \
   "iso HOST" "Generate an ISO image of HOST" \
+  "vm HOST" "Generate a vm for HOST" \
+  "vm-run HOST" "Generate and run a vm for HOST" \
   "install HOST [ARGS]" "Shortcut for nixos-install" \
   "home HOST USER [switch]" "Home-manager config of USER from HOST" \
   "HOST (switch|boot|test)" "Shortcut for nixos-rebuild" \
@@ -83,6 +85,27 @@ case "$1" in
     nix build \
       "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.iso" \
       "${@:3}"
+    ;;
+
+  "vm")
+    nix build \
+      "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.vm" \
+      -o \
+      "$DEVSHELL_ROOT/vm/$2" \
+      "${@:3}"
+    ;;
+
+  "vm-run")
+    nix build \
+      "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.vm" \
+      -o \
+      "$DEVSHELL_ROOT/vm/$2" \
+      "${@:3}" \
+      && \
+      (export NIX_DISK_IMAGE="$DEVSHELL_ROOT/vm/$2.qcow2" \
+      && \
+      "$DEVSHELL_ROOT/vm/$2/bin/run-$2-vm" \
+      )
     ;;
 
   "install")

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -22,7 +22,7 @@ usage () {
   "doi HOST" "Generate DigitalOcean image of HOST" \
   "iso HOST" "Generate an ISO image of HOST" \
   "vm HOST" "Generate a vm for HOST" \
-  "vm-run HOST" "Generate and run a vm for HOST" \
+  "vm run HOST" "run a one-shot vm for HOST" \
   "install HOST [ARGS]" "Shortcut for nixos-install" \
   "home HOST USER [switch]" "Home-manager config of USER from HOST" \
   "HOST (switch|boot|test)" "Shortcut for nixos-rebuild" \
@@ -88,26 +88,24 @@ case "$1" in
     ;;
 
   "vm")
-    nix build \
-      "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.vm" \
-      -o \
-      "$DEVSHELL_ROOT/vm/$2" \
-      "${@:3}"
-    ;;
-
-  "vm-run")
-    nix build \
-      "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.vm" \
-      -o \
-      "$DEVSHELL_ROOT/vm/$2" \
-      "${@:3}" \
+    if [[ "$2" == "run" ]]; then
+      rm -rf "$DEVSHELL_ROOT/vm/tmp/$3"* \
+      && nix build \
+        "$DEVSHELL_ROOT#nixosConfigurations.$3.config.system.build.vm" \
+        -o "$DEVSHELL_ROOT/vm/tmp/$3" \
+        "${@:4}" \
       && \
-      rm -f "$DEVSHELL_ROOT/vm/$2.qcow2" \
-      && \
-      (export NIX_DISK_IMAGE="$DEVSHELL_ROOT/vm/$2.qcow2" \
-      && \
-      "$DEVSHELL_ROOT/vm/$2/bin/run-$2-vm" \
-      )
+      ( \
+        export NIX_DISK_IMAGE="$DEVSHELL_ROOT/vm/tmp/$3.qcow2" \
+        && "$DEVSHELL_ROOT/vm/tmp/$3/bin/run-$3-vm" \
+      ) \
+      && rm -rf "$DEVSHELL_ROOT/vm/tmp/$3"* \
+    else
+      nix build \
+        "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.vm" \
+        -o "$DEVSHELL_ROOT/vm/$2" \
+        "${@:3}" \
+    fi
     ;;
 
   "install")

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -106,6 +106,9 @@ case "$1" in
         "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.vm" \
         -o "$DEVSHELL_ROOT/vm/$2" \
         "${@:3}" \
+      && echo "export NIX_DISK_IMAGE=\"$DEVSHELL_ROOT/vm/$2.qcow2\"" > "$DEVSHELL_ROOT/vm/run-$2" \
+      && echo "$DEVSHELL_ROOT/vm/$2/bin/run-$2-vm" >> "$DEVSHELL_ROOT/vm/run-$2" \
+      && chmod +x "$DEVSHELL_ROOT/vm/run-$2"
     fi
     ;;
 


### PR DESCRIPTION
Closes #41.

That was far easier than what I thought! bash scripting is really straight forward :smile: 
What this does:
- `flk vm HOST` generates the vm for the host under the vm folder, the link to the nix store result is named after the HOST.
- `flk vm-run HOST` generates the vm as `flk vm HOST` and runs the vm creating the disk image under the vm folder as `HOST.qcow2`

Here is the tree after doing a `flk vm-run NixOS`:
```
vm
├── NixOS -> /nix/store/<hash>-nixos-vm
└── NixOS.qcow2
```

This allows for fast iteration on the NixOS configuration which is super useful, I already love it! :heart: 