### PR TITLE
Changed output from nix build for iso and doi command

### DIFF
--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -82,6 +82,8 @@ case "$1" in
   "iso")
     nix build \
       "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.iso" \
+      -o \
+      "$DEVSHELL_ROOT/iso/$2" \
       "${@:3}"
     ;;
 

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -76,6 +76,8 @@ case "$1" in
   "doi")
     nix build \
       "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.digitalOcean" \
+      -o \
+      "$DEVSHELL_ROOT/doi/$2" \
       "${@:3}"
     ;;
 

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -85,7 +85,7 @@ case "$1" in
     nix build \
       "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.iso" \
       -o \
-      "$DEVSHELL_ROOT/iso/$2" \
+      "$DEVSHELL_ROOT/iso/$2.iso" \
       "${@:3}"
     ;;
 


### PR DESCRIPTION
Closes #44.

This will make the command easier and more predictable.
We can also as a result add the iso folder in the devos gitignore.