### PR TITLE
Add default customBuilds from nixos-generators

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,6 +103,26 @@
         "type": "github"
       }
     },
+    "nixos-generators": {
+      "inputs": {
+        "nixpkgs": [
+          "nixlib"
+        ]
+      },
+      "locked": {
+        "lastModified": 1623231956,
+        "narHash": "sha256-XGt7m0z10TOgxPCLEi+G6yRSLkkh2RNCY06ahI+e+s0=",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "0ee263b3cd04f15c7337d8154110b8815efd867d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1610942247,
@@ -139,6 +159,7 @@
         "deploy": "deploy",
         "devshell": "devshell",
         "nixlib": "nixlib",
+        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs_2",
         "utils": "utils_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,24 @@
       devshell.url = "github:numtide/devshell";
       utils.url = "github:gytis-ivaskevicius/flake-utils-plus/staging";
       nixlib.url = "github:divnix/nixpkgs.lib";
+      nixos-generators.url = "github:nix-community/nixos-generators";
+      # We only use the nixosModules output which only needs nixpkgs lib
+      nixos-generators.inputs.nixpkgs.follows = "nixlib";
 
       # Only used for development
       nixpkgs.url = "github:nixos/nixpkgs";
     };
 
-  outputs = inputs@{ self, nixlib, nixpkgs, deploy, devshell, utils, ... }:
+  outputs =
+    { self
+    , nixlib
+    , nixpkgs
+    , deploy
+    , devshell
+    , utils
+    , nixos-generators
+    , ...
+    }@inputs:
     let
       lib = nixlib.lib.makeExtensible (self:
         let combinedLib = nixlib.lib // self; in
@@ -21,7 +33,11 @@
           attrs = import ./src/attrs.nix { lib = combinedLib; };
           lists = import ./src/lists.nix { lib = combinedLib; };
           strings = import ./src/strings.nix { lib = combinedLib; };
-          modules = import ./src/modules.nix { lib = combinedLib; };
+
+          modules = import ./src/modules.nix {
+            lib = combinedLib;
+            inherit nixos-generators;
+          };
 
           importers = import ./src/importers.nix {
             lib = combinedLib;

--- a/src/mkFlake/default.nix
+++ b/src/mkFlake/default.nix
@@ -30,6 +30,7 @@ let
         recursion errors. It is recommended to update to 21.05 to use either feature.
       '' { });
     })
+    customBuilds
   ];
 
   stripChannel = channel: removeAttrs channel [

--- a/src/modules.nix
+++ b/src/modules.nix
@@ -2,14 +2,6 @@
 {
   customBuilds =
     { lib, pkgs, config, baseModules, modules, ... }@args:
-    let
-      builds = lib.mapAttrs
-        (format: module:
-          let build = config.lib.digga.mkBuild module; in
-          build // build.config.system.build.${build.config.formatAttr}
-        )
-        nixos-generators.nixosModules;
-    in
     {
       # created in modules system for access to specialArgs and modules
       lib.digga.mkBuild = buildModule:
@@ -21,8 +13,17 @@
           # so try to pass that to eval if possible.
           specialArgs = args.specialArgs or { };
         };
-      # ensure these builds can be overriden by other modules
-      system.build = lib.mkBefore builds;
+      system.build =
+        let
+          builds = lib.mapAttrs
+            (format: module:
+              let build = config.lib.digga.mkBuild module; in
+              build // build.config.system.build.${build.config.formatAttr}
+            )
+            nixos-generators.nixosModules;
+        in
+        # ensure these builds can be overriden by other modules
+        lib.mkBefore builds;
     };
 
   hmDefaults = { specialArgs, modules }:

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -77,8 +77,6 @@ case "$1" in
   "build")
     nix build \
       "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.$3" \
-      -o \
-      "$DEVSHELL_ROOT/builds/$2/$3" \
       "${@:4}"
     ;;
 

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -19,8 +19,7 @@ usage () {
   "up" "Generate $DEVSHELL_ROOT/hosts/up-$HOSTNAME.nix" \
   "update [INPUT]" "Update and commit the lock file, or specific input" \
   "get (core|community) [DEST]" "Copy the desired template to DEST" \
-  "doi HOST" "Generate DigitalOcean image of HOST" \
-  "iso HOST" "Generate an ISO image of HOST" \
+  "build HOST BUILD" "Build a variant of your configuration from system.build"
   "vm HOST" "Generate a vm for HOST" \
   "vm run HOST" "run a one-shot vm for HOST" \
   "install HOST [ARGS]" "Shortcut for nixos-install" \
@@ -75,20 +74,12 @@ case "$1" in
     fi
     ;;
 
-  "doi")
+  "build")
     nix build \
-      "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.digitalOcean" \
+      "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.$3" \
       -o \
-      "$DEVSHELL_ROOT/doi/$2.qcow2" \
-      "${@:3}"
-    ;;
-
-  "iso")
-    nix build \
-      "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.iso" \
-      -o \
-      "$DEVSHELL_ROOT/iso/$2.iso" \
-      "${@:3}"
+      "$DEVSHELL_ROOT/$3/$2.$3" \
+      "${@:4}"
     ;;
 
   "vm")

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -78,7 +78,7 @@ case "$1" in
     nix build \
       "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.$3" \
       -o \
-      "$DEVSHELL_ROOT/builds/$2/$3/" \
+      "$DEVSHELL_ROOT/builds/$2/$3" \
       "${@:4}"
     ;;
 

--- a/src/pkgs-lib/shell/flk.sh
+++ b/src/pkgs-lib/shell/flk.sh
@@ -78,7 +78,7 @@ case "$1" in
     nix build \
       "$DEVSHELL_ROOT#nixosConfigurations.$2.config.system.build.$3" \
       -o \
-      "$DEVSHELL_ROOT/$3/$2.$3" \
+      "$DEVSHELL_ROOT/builds/$2/$3/" \
       "${@:4}"
     ;;
 

--- a/tests/fullFlake/modules/customBuilds.nix
+++ b/tests/fullFlake/modules/customBuilds.nix
@@ -26,9 +26,5 @@ in
         }
       ];
     })).config.home-manager.users;
-
-    digitalOcean = (mkBuild ({ modulesPath, ... }: {
-      imports = [ "${modulesPath}/virtualisation/digital-ocean-image.nix" ];
-    })).config.system.build.digitalOceanImage;
   };
 }


### PR DESCRIPTION
Idea is that we create an entry in `system.build` for every format in nixos-generators. Also introduce `config.lib.digga.mkBuild` so devos's customBuilds doesn't have to re-implement the logic.

closes #49 cc @Lassulus