### PR TITLE
fix: make nixos.hostDefaults.channelName required

### DIFF
--- a/src/mkFlake/default.nix
+++ b/src/mkFlake/default.nix
@@ -149,7 +149,7 @@ lib.systemFlake (lib.mergeAny
                     };
                   };
 
-                  profilesTests = 
+                  profilesTests =
                     # only for hosts that also are the same system as the current check attribute
                     if (hostConfigsOnThisSystem != [ ])
                     then lib.mapAttrs' createProfilesTestOp hostConfigsOnThisSystemWithSuites

--- a/src/mkFlake/evalArgs.nix
+++ b/src/mkFlake/evalArgs.nix
@@ -110,14 +110,21 @@ let
         };
       };
 
-      channelNameOpt = {
+      channelNameOpt = required: {
         channelName = mkOption {
-          type = with types; nullOr channelType;
-          default = null;
           description = ''
             Channel this host should follow
           '';
-        };
+        }
+        //
+        (
+          if required then {
+            type = with types; channelType;
+          } else {
+            type = with types; nullOr channelType;
+            default = null;
+          }
+        );
       };
 
       modulesOpt = {
@@ -286,13 +293,13 @@ let
       hostType = with types; attrsOf (submoduleWith {
         modules = [
           # per-host modules not exported, no external modules
-          { options = systemOpt // channelNameOpt // modulesOpt; }
+          { options = systemOpt // (channelNameOpt false) // modulesOpt; }
         ];
       });
 
       hostDefaultsType = name: with types; submoduleWith {
         modules = [
-          { options = systemOpt // channelNameOpt // externalModulesOpt // (exportedModulesOpt name); }
+          { options = systemOpt // (channelNameOpt true) // externalModulesOpt // (exportedModulesOpt name); }
         ];
       };
 


### PR DESCRIPTION
In several places `mkFlake` assumes an valid value is set, here.

fixes: #76

- [x] A nicer error message:
```
nix develop
warning: Git tree '/home/blaggacao/ghq/github.com/blaggacao/devos' is dirty
error: The option `nixos.hostDefaults.channelName' is used but not defined.
```
