### PR TITLE
external not exported rename

### DIFF
--- a/doc/api-reference-devshell.md
+++ b/doc/api-reference-devshell.md
@@ -19,13 +19,12 @@ submodule or path convertible to it
 
 
 
-## devshell.externalModules
-modules to include that won't be exported
-meant importing modules from external flakes
+## devshell.modules
+modules to include in all hosts and export to devshellModules output
 
 
 *_Type_*:
-list of valid modules or anything convertible to it
+list of valid module or path convertible to its or anything convertible to it
 
 
 *_Default_*
@@ -36,12 +35,13 @@ list of valid modules or anything convertible to it
 
 
 
-## devshell.modules
-modules to include in all hosts and export to devshellModules output
+## devshell.nonExportedModules
+modules to include that won't be exported
+meant importing modules e.g. from external flakes
 
 
 *_Type_*:
-list of valid module or path convertible to its or anything convertible to it
+list of valid modules or anything convertible to it
 
 
 *_Default_*

--- a/doc/api-reference-home.md
+++ b/doc/api-reference-home.md
@@ -18,23 +18,6 @@ submodule or path convertible to it
 
 
 
-## home.externalModules
-modules to include that won't be exported
-meant importing modules from external flakes
-
-
-*_Type_*:
-list of valid modules or anything convertible to it
-
-
-*_Default_*
-```
-[]
-```
-
-
-
-
 ## home.importables
 Packages of paths to be passed to modules as `specialArgs`.
 
@@ -69,6 +52,23 @@ null
 
 ## home.modules
 modules to include in all hosts and export to homeModules output
+
+
+*_Type_*:
+list of valid modules or anything convertible to it
+
+
+*_Default_*
+```
+[]
+```
+
+
+
+
+## home.nonExportedModules
+modules to include that won't be exported
+meant importing modules e.g. from external flakes
 
 
 *_Type_*:

--- a/doc/api-reference-nixos.md
+++ b/doc/api-reference-nixos.md
@@ -49,9 +49,8 @@ channel defined in `channels`
 
 
 
-## nixos.hostDefaults.externalModules
-modules to include that won't be exported
-meant importing modules from external flakes
+## nixos.hostDefaults.modules
+modules to include in all hosts and export to nixosModules output
 
 
 *_Type_*:
@@ -66,8 +65,9 @@ list of valid modules or anything convertible to it
 
 
 
-## nixos.hostDefaults.modules
-modules to include in all hosts and export to nixosModules output
+## nixos.hostDefaults.nonExportedModules
+modules to include that won't be exported
+meant importing modules e.g. from external flakes
 
 
 *_Type_*:

--- a/examples/hmOnly/home/default.nix
+++ b/examples/hmOnly/home/default.nix
@@ -4,7 +4,7 @@ let
 in
 {
   imports = [ (lib.importModules ./modules) ];
-  externalModules = [ ];
+  nonExportedModules = [ ];
   importables = rec {
     profiles = lib.rakeLeaves ./profiles;
     suites = with profiles; {

--- a/src/mkFlake/fup-adapter.nix
+++ b/src/mkFlake/fup-adapter.nix
@@ -25,7 +25,7 @@ let
   defaultHostModules = [
     (internal-modules.hmNixosDefaults {
       specialArgs = config.home.importables;
-      modules = config.home.modules ++ config.home.externalModules;
+      modules = config.home.modules ++ config.home.nonExportedModules;
     })
     (internal-modules.globalDefaults {
       hmUsers = config.home.users;
@@ -53,8 +53,10 @@ let
   # but for proper default handling in fup, null args have to be removed
   stripHost = args: removeAttrs (lib.filterAttrs (_: arg: arg != null) args) [
     # arguments in our hosts/hostDefaults api that shouldn't be passed to fup
-    "externalModules"
+    "nonExportedModules"
     "tests"
+    # TODO: remove deprecation boilerplate
+    "externalModules"
   ];
 
   diggaFupArgs = {
@@ -79,7 +81,7 @@ let
     hostDefaults = flake-utils-plus.lib.mergeAny (stripHost config.nixos.hostDefaults) {
       # add `self` & `inputs` as specialargs so their libs can be used in imports
       specialArgs = config.nixos.importables // { inherit (config) self inputs; };
-      modules = config.nixos.hostDefaults.externalModules ++ defaultHostModules;
+      modules = config.nixos.hostDefaults.nonExportedModules ++ defaultHostModules;
     };
 
     nixosModules = flake-utils-plus.lib.exportModules config.nixos.hostDefaults.modules;

--- a/src/mkFlake/outputs-builder.nix
+++ b/src/mkFlake/outputs-builder.nix
@@ -20,7 +20,7 @@ let
     home-manager.lib.homeManagerConfiguration {
       inherit username homeDirectory pkgs system;
 
-      extraModules = config.home.modules ++ config.home.externalModules;
+      extraModules = config.home.modules ++ config.home.nonExportedModules;
       extraSpecialArgs = config.home.importables;
 
       configuration = {
@@ -53,7 +53,7 @@ in
       eval = import "${devshell}/modules" pkgs;
       configuration = {
         name = lib.mkDefault config.nixos.hostDefaults.channelName;
-        imports = config.devshell.modules ++ config.devshell.externalModules;
+        imports = config.devshell.modules ++ config.devshell.nonExportedModules;
       };
     in
     (eval {


### PR DESCRIPTION
as the use case for digga expands into downstream
lib expantion the "external" naming is no more
appropriate when downstream lib functions purposefully
bundle and intentionally _re-export_ upstream art.