### PR TITLE
mkFlake/options: add pathToOr for modules options

### DIFF
--- a/doc/api-reference-devshell.md
+++ b/doc/api-reference-devshell.md
@@ -25,7 +25,7 @@ meant importing modules from external flakes
 
 
 *_Type_*:
-list of valid modules or anything convertible to it
+list of valid modules or anything convertible to it or path convertible to it
 
 
 *_Default_*

--- a/doc/api-reference-home.md
+++ b/doc/api-reference-home.md
@@ -24,7 +24,7 @@ meant importing modules from external flakes
 
 
 *_Type_*:
-list of valid modules or anything convertible to it
+list of valid modules or anything convertible to it or path convertible to it
 
 
 *_Default_*
@@ -72,7 +72,7 @@ modules to include in all hosts and export to homeModules output
 
 
 *_Type_*:
-list of valid modules or anything convertible to it
+list of valid modules or anything convertible to it or path convertible to it
 
 
 *_Default_*

--- a/doc/api-reference-nixos.md
+++ b/doc/api-reference-nixos.md
@@ -55,7 +55,7 @@ meant importing modules from external flakes
 
 
 *_Type_*:
-list of valid modules or anything convertible to it
+list of valid modules or anything convertible to it or path convertible to it
 
 
 *_Default_*
@@ -71,7 +71,7 @@ modules to include in all hosts and export to nixosModules output
 
 
 *_Type_*:
-list of valid modules or anything convertible to it
+list of valid modules or anything convertible to it or path convertible to it
 
 
 *_Default_*
@@ -135,7 +135,7 @@ modules to include
 
 
 *_Type_*:
-list of valid modules or anything convertible to it
+list of valid modules or anything convertible to it or path convertible to it
 
 
 *_Default_*

--- a/src/mkFlake/options.nix
+++ b/src/mkFlake/options.nix
@@ -171,7 +171,7 @@ let
 
   modulesOpt = {
     modules = mkOption {
-      type = with types; modulesType;
+      type = with types; pathToOr modulesType;
       default = [ ];
       description = ''
         modules to include
@@ -180,7 +180,7 @@ let
   };
 
   exportedModulesOpt' = name: {
-    type = with types; modulesType;
+    type = with types; pathToOr modulesType;
     default = [ ];
     description = ''
       modules to include in all hosts and export to ${name}Modules output
@@ -200,7 +200,7 @@ let
   # modules in each host don't get exported
   externalModulesOpt = {
     externalModules = mkOption {
-      type = with types; modulesType;
+      type = with types; pathToOr modulesType;
       default = [ ];
       description = ''
         modules to include that won't be exported


### PR DESCRIPTION
I still prefer the `modules = ./modules/module-list.nix` pattern, this makes that possible without having to use `import`.