### PR TITLE
Update module/special arguments

### DIFF
--- a/src/mkFlake/fup-adapter.nix
+++ b/src/mkFlake/fup-adapter.nix
@@ -24,7 +24,7 @@ let
 
   defaultHostModules = [
     (internal-modules.hmNixosDefaults {
-      specialArgs = config.home.importables;
+      specialArgs = config.home.importables // { inherit (config) self inputs; };
       modules = config.home.modules ++ config.home.exportedModules;
     })
     (internal-modules.globalDefaults {

--- a/src/mkFlake/outputs-builder.nix
+++ b/src/mkFlake/outputs-builder.nix
@@ -21,7 +21,7 @@ let
       inherit username homeDirectory pkgs system;
 
       extraModules = config.home.modules ++ config.home.exportedModules;
-      extraSpecialArgs = config.home.importables;
+      extraSpecialArgs = config.home.importables // { inherit (config) self inputs; };
 
       configuration = {
         imports = [ configuration ];

--- a/src/modules.nix
+++ b/src/modules.nix
@@ -54,8 +54,10 @@
 
       _module.args = {
         inherit hmUsers;
-        hosts = builtins.mapAttrs (_: host: host.config)
-          (removeAttrs self.nixosConfigurations [ config.networking.hostName ]);
+        hosts = throw ''
+          The `hosts` module argument has been removed, you should instead use
+          `self.nixosConfigurations`, with the `self` module argument.
+        '';
       };
 
       system.configurationRevision = lib.mkIf (self ? rev) self.rev;


### PR DESCRIPTION
 - Remove `hosts` module argument, fixes #104 
 - Add `self` and `inputs` as a special argument for home-manager configs(portable & non-portable)