### PR TITLE
nix: remove ca-references feature flag

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1630859749,
-        "narHash": "sha256-qkoU2rIbbP2+T0dfcqXW35GCWNsi0Y1IgN9BELmt4Zo=",
+        "lastModified": 1638994888,
+        "narHash": "sha256-iz/ynGNZlvqKCOnFrEKqGA+BVKGQMG+g2JT+e3OOLN8=",
         "owner": "divnix",
         "repo": "flake-utils-plus",
-        "rev": "a4e267e3fc87e60c5029c6c3855935ff1ff3018e",
+        "rev": "b4f9f517574cb7bd6ee3f19c72c19634c9f536e1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "DevOS environment configuriguration library.";
 
-  nixConfig.extra-experimental-features = "nix-command flakes ca-references";
+  nixConfig.extra-experimental-features = "nix-command flakes";
   nixConfig.extra-substituters = "https://nrdxp.cachix.org https://nix-community.cachix.org";
   nixConfig.extra-trusted-public-keys = "nrdxp.cachix.org-1:Fc5PSqY2Jm1TrWfm88l6cvGWwz3s93c6IOifQWnhNW4= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=";
 

--- a/modules/nix-config.nix
+++ b/modules/nix-config.nix
@@ -4,7 +4,6 @@ let
   experimental-features = [
     "flakes"
     "nix-command"
-    "ca-references"
   ];
   substituters = [
     "https://nrdxp.cachix.org" # quality of life cache from our CI

--- a/shell.nix
+++ b/shell.nix
@@ -101,7 +101,7 @@ devshell.mkShell {
     {
       name = "NIX_CONFIG";
       value =
-        ''extra-experimental-features = nix-command flakes ca-references
+        ''extra-experimental-features = nix-command flakes
         extra-substituters = https://nrdxp.cachix.org https://nix-community.cachix.org
         extra-trusted-public-keys = nrdxp.cachix.org-1:Fc5PSqY2Jm1TrWfm88l6cvGWwz3s93c6IOifQWnhNW4= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs='';
     }


### PR DESCRIPTION
This experimental feature has been removed from Nix in unstable versions recently, and with this set, it now pops up an unsupressable warning message. Not so bad on its own, but when using <kbd>Tab</kbd> completion it corrupts the output.