### PR TITLE
Ensure home-manager portable user configurations are called with expected module args

### DIFF
--- a/examples/hmOnly/home/users/testuser.nix
+++ b/examples/hmOnly/home/users/testuser.nix
@@ -1,10 +1,12 @@
-{ suites, ... }:
+{ pkgs, suites, ... }:
 let
   name = "Test User";
   email = "test@example.com";
 in
 {
   imports = suites.shell;
+
+  home.packages = [ pkgs.hello ];
 
   programs.browserpass.enable = true;
   programs.starship.enable = true;

--- a/src/mkFlake/options.nix
+++ b/src/mkFlake/options.nix
@@ -94,7 +94,7 @@ let
     description = "nix flake";
   };
 
-  userType = with types; pathToOr (functionTo attrs) // {
+  userType = with types; pathToOr moduleType // {
     description = "HM user config";
   };
 


### PR DESCRIPTION
Type-check `home-manager` portable user configurations as modules (`moduleType`) rather than as functions evaluating to attribute sets (`functionTo attrs`).  This ensures that they get invoked with all expected module arguments (`pkgs`, `lib`, etc.).

Also update `./examples/hmOnly` so that the `testuser` configuration references the `pkgs` module arg, thus testing that the switch to `moduleType` works as intended.

Closes #119