### PR TITLE
flake: remove anti-corruption layer and use nixlib

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,9 +21,7 @@
         "nixpkgs": [
           "latest"
         ],
-        "utils": [
-          "flake-utils"
-        ]
+        "utils": "utils"
       },
       "locked": {
         "lastModified": 1632822684,
@@ -87,9 +85,7 @@
     },
     "flake-utils-plus": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ]
+        "flake-utils": "flake-utils"
       },
       "locked": {
         "lastModified": 1638994888,
@@ -108,7 +104,7 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "nixlib"
         ]
       },
       "locked": {
@@ -142,11 +138,39 @@
         "type": "github"
       }
     },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1641688481,
+        "narHash": "sha256-6L+EU12xLDHby7y8elgFtRKVBxix+7qV8DhVgXqrKZo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f697717b3d3a074ffc16c8c8227504f0db292886",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixlib_2": {
+      "locked": {
+        "lastModified": 1641688481,
+        "narHash": "sha256-6L+EU12xLDHby7y8elgFtRKVBxix+7qV8DhVgXqrKZo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f697717b3d3a074ffc16c8c8227504f0db292886",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixos-generators": {
       "inputs": {
-        "nixlib": [
-          "nixlib"
-        ],
+        "nixlib": "nixlib_2",
         "nixpkgs": [
           "blank"
         ]
@@ -186,15 +210,27 @@
         "blank": "blank",
         "deploy": "deploy",
         "devshell": "devshell",
-        "flake-utils": "flake-utils",
         "flake-utils-plus": "flake-utils-plus",
         "home-manager": "home-manager",
         "latest": "latest",
-        "nixlib": [
-          "nixpkgs"
-        ],
+        "nixlib": "nixlib",
         "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -9,14 +9,14 @@
     {
       nixpkgs.url = "github:nixos/nixpkgs/release-21.11";
       latest.url = "github:nixos/nixpkgs/nixos-unstable";
-      nixlib.follows = "nixpkgs"; # "github:nix-community/nixpkgs.lib";
+      nixlib.url = "github:nix-community/nixpkgs.lib";
       blank.url = "github:divnix/blank";
+
       deploy.url = "github:serokell/deploy-rs";
       deploy.inputs.nixpkgs.follows = "latest";
-      # deploy.inputs.utils.follows = "utils/flake-utils";
 
       home-manager.url = "github:nix-community/home-manager/release-21.11";
-      home-manager.inputs.nixpkgs.follows = "nixpkgs";
+      home-manager.inputs.nixpkgs.follows = "nixlib";
 
       devshell.url = "github:numtide/devshell";
       # fork with urgent fixes that can't be added quickly upstream in respect of upstream user base
@@ -24,17 +24,6 @@
 
       nixos-generators.url = "github:nix-community/nixos-generators";
       nixos-generators.inputs.nixpkgs.follows = "blank";
-      nixos-generators.inputs.nixlib.follows = "nixlib";
-      # nixos-generators.inputs.utils.follows = "utils/flake-utils";
-
-      # start ANTI CORRUPTION LAYER
-      # remove after https://github.com/NixOS/nix/pull/4641
-      # and uncomment the poper lines using "utils/flake-utils" above
-      flake-utils.url = "github:numtide/flake-utils";
-      flake-utils-plus.inputs.flake-utils.follows = "flake-utils";
-      deploy.inputs.utils.follows = "flake-utils";
-      nixos-generators.inputs.utils.follows = "flake-utils";
-      # end ANTI CORRUPTION LAYER
     };
 
   outputs =
@@ -51,26 +40,26 @@
     }@inputs:
     let
 
-      tests = import ./src/tests.nix { inherit (nixpkgs) lib; };
+      tests = import ./src/tests.nix { inherit (nixlib) lib; };
 
       internal-modules = import ./src/modules.nix {
-        inherit (nixpkgs) lib;
+        inherit (nixlib) lib;
         inherit nixos-generators;
       };
 
       importers = import ./src/importers.nix {
-        inherit (nixpkgs) lib;
+        inherit (nixlib) lib;
       };
 
       generators = import ./src/generators.nix {
-        inherit (nixpkgs) lib;
+        inherit (nixlib) lib;
         inherit deploy;
       };
 
       mkFlake =
         let
           mkFlake' = import ./src/mkFlake {
-            inherit (nixpkgs) lib;
+            inherit (nixlib) lib;
             inherit (flake-utils-plus.inputs) flake-utils;
             inherit deploy devshell home-manager flake-utils-plus internal-modules tests;
           };
@@ -99,7 +88,7 @@
 
       # DEPRECATED - will be removed timely
       deprecated = import ./deprecated.nix {
-        inherit (nixpkgs) lib;
+        inherit (nixlib) lib;
         inherit (self) nixosModules;
         inherit flake-utils-plus internal-modules importers;
       };


### PR DESCRIPTION
This means the only remaining part of digga lib that uses nixpkgs is deploy, which can hopefully be removed with use of the deploy overlay instead of `deploy.lib`.

A small piece of #115 focusing on the follows changes