### PR TITLE
Remove customBuilds, nixos-generate has --flake

### DIFF
--- a/examples/devos/flake.lock
+++ b/examples/devos/flake.lock
@@ -369,6 +369,21 @@
         "type": "github"
       }
     },
+    "nixlib_2": {
+      "locked": {
+        "lastModified": 1636849918,
+        "narHash": "sha256-nzUK6dPcTmNVrgTAC1EOybSMsrcx+QrVPyqRdyKLkjA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "28a5b0557f14124608db68d3ee1f77e9329e9dd5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixos": {
       "locked": {
         "lastModified": 1643463207,
@@ -396,6 +411,25 @@
         "owner": "nix-community",
         "repo": "nixos-generators",
         "rev": "05a3eb158a9c7746a5d463726d7f7cccf07500e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "type": "github"
+      }
+    },
+    "nixos-generators_2": {
+      "inputs": {
+        "nixlib": "nixlib_2",
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1647521142,
+        "narHash": "sha256-ZwK8n5yCYHjmSLPqwXiebUyQxSHQ3HyKAxs4psksuVc=",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "9f56b704ff3073436c3b93d63669ee773c592aa3",
         "type": "github"
       },
       "original": {
@@ -457,6 +491,22 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "19574af0af3ffaf7c9e359744ed32556f34536bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1637186689,
+        "narHash": "sha256-NU7BhgnwA/3ibmCeSzFK6xGi+Bari9mPfn+4cBmyEjw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7fad01d9d5a3f82081c00fb57918d64145dc904c",
         "type": "github"
       },
       "original": {
@@ -532,6 +582,7 @@
         "latest": "latest_2",
         "naersk": "naersk",
         "nixos": "nixos",
+        "nixos-generators": "nixos-generators_2",
         "nixos-hardware": "nixos-hardware",
         "nur": "nur",
         "nvfetcher": "nvfetcher"

--- a/examples/devos/flake.nix
+++ b/examples/devos/flake.nix
@@ -39,6 +39,8 @@
       naersk.inputs.nixpkgs.follows = "nixos";
 
       nixos-hardware.url = "github:nixos/nixos-hardware";
+
+      nixos-generators.url = "github:nix-community/nixos-generators";
     };
 
   outputs =

--- a/examples/devos/shell/devos.nix
+++ b/examples/devos/shell/devos.nix
@@ -45,10 +45,11 @@ in
     (docs mdbook)
     (devos inputs.deploy.packages.${pkgs.system}.deploy-rs)
   ]
-
   ++ lib.optional
     (system != "i686-linux")
     (devos cachix)
-
+  ++ lib.optional
+    (system != "aarch64-darwin")
+    (devos inputs.nixos-generators.defaultPackage.${pkgs.system})
   ;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -169,42 +169,6 @@
         "type": "github"
       }
     },
-    "nixlib_2": {
-      "locked": {
-        "lastModified": 1641688481,
-        "narHash": "sha256-6L+EU12xLDHby7y8elgFtRKVBxix+7qV8DhVgXqrKZo=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f697717b3d3a074ffc16c8c8227504f0db292886",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib_2",
-        "nixpkgs": [
-          "blank"
-        ]
-      },
-      "locked": {
-        "lastModified": 1637655461,
-        "narHash": "sha256-kXZPbclN3gKwjhp2/RYFDFpAsSBwzX1iLF4EcnHZsPQ=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "05a3eb158a9c7746a5d463726d7f7cccf07500e4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1638222206,
@@ -231,7 +195,6 @@
         "home-manager": "home-manager",
         "latest": "latest",
         "nixlib": "nixlib",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,6 @@
       devshell.url = "github:numtide/devshell";
       flake-utils-plus.url = "github:gytis-ivaskevicius/flake-utils-plus";
 
-      nixos-generators.url = "github:nix-community/nixos-generators";
-      nixos-generators.inputs.nixpkgs.follows = "blank";
-
       flake-compat = {
         url = "github:edolstra/flake-compat";
         flake = false;
@@ -38,7 +35,6 @@
     , deploy
     , devshell
     , flake-utils-plus
-    , nixos-generators
     , home-manager
     , ...
     }@inputs:
@@ -48,7 +44,6 @@
 
       internal-modules = import ./src/modules.nix {
         inherit (nixlib) lib;
-        inherit nixos-generators;
       };
 
       importers = import ./src/importers.nix {

--- a/src/mkFlake/fup-adapter.nix
+++ b/src/mkFlake/fup-adapter.nix
@@ -39,7 +39,6 @@ let
       ''
         { });
     })
-    internal-modules.customBuilds
   ];
 
   unifyOverlays = channels: map (o: if builtins.isFunction (o null null) then o channels else o);

--- a/src/modules.nix
+++ b/src/modules.nix
@@ -1,34 +1,5 @@
-{ lib, nixos-generators }:
+{ lib }:
 {
-  customBuilds =
-    { lib, pkgs, config, baseModules, modules, ... }@args:
-    {
-      # created in modules system for access to specialArgs and modules
-      lib.digga.mkBuild = buildModule:
-        import "${toString pkgs.path}/nixos/lib/eval-config.nix" {
-          inherit (pkgs) system;
-          inherit baseModules;
-          modules = modules ++ [ buildModule ];
-          # Newer versions of module system pass specialArgs to modules
-          # so try to pass that to eval if possible.
-          specialArgs = args.specialArgs or { };
-        };
-      system.build =
-        let
-          builds = lib.mapAttrs
-            (format: module:
-              let build = config.lib.digga.mkBuild module;
-              in
-              build // build.config.system.build.${build.config.formatAttr}
-            )
-            (if (lib.versionAtLeast config.system.stateVersion "22.05") then
-              builtins.removeAttrs nixos-generators.nixosModules [ "vm" ]
-            else nixos-generators);
-        in
-        # ensure these builds can be overriden by other modules
-        lib.mkDefault builds;
-    };
-
   hmNixosDefaults = { specialArgs, modules }:
     { options, ... }: {
       config = lib.optionalAttrs (options ? home-manager) {


### PR DESCRIPTION
nixos-generators now has --flake support, so theres no reason for us to export all the builds here. Lets just offload this responsibility to nixos-generators.

Somewhat blocked by nix-community/nixos-generators#138, so that we don't need to make our hosts overridable.