### PR TITLE
Remove suites, profiles, and old importer code

### DIFF
--- a/deprecated.nix
+++ b/deprecated.nix
@@ -1,94 +1,9 @@
 { lib, flake-utils-plus, internal-modules, importers, nixosModules }:
-let
-  importers' = importers;
-in
 lib.warn ''
   You are accessing a deprecated item of the digga lib.
   Please update timely, it will be remove soon.
 ''
 rec {
-
-  mkSuites = lib.warn ''
-    Deprecated Function: mkSuites.
-  ''
-    (
-      { suites, profiles }:
-      let
-        profileSet = lib.genAttrs' profiles (path: {
-          name = baseNameOf path;
-          value = mkProfileAttrs (toString path);
-        });
-      in
-      lib.mapAttrs (_: v: lib.profileMap v) (suites profileSet)
-    )
-  ;
-
-  mkProfileAttrs = lib.warn ''
-    Deprecated Function: mkProfileAttrs.
-  ''
-    (
-      dir:
-      let
-        imports =
-          let
-            files = builtins.readDir dir;
-
-            p = n: v:
-              v == "directory"
-              && n != "profiles";
-          in
-          lib.filterAttrs p files;
-
-        f = n: _:
-          lib.optionalAttrs
-            (lib.pathExists (dir + "/${n}/default.nix"))
-            { default = dir + "/${n}"; }
-          // mkProfileAttrs (dir + "/${n}");
-      in
-      lib.mapAttrs f imports
-    )
-  ;
-
-  profileMap =
-    lib.warn ''
-      Deprecated Function: profileMap.
-    ''
-      (
-        list: map (profile: profile.default) (lib.flatten list)
-      )
-  ;
-
-
-  exporters =
-    lib.warn ''
-      Deprecated Attribute Set: lib.exporters.
-
-      Please use export* functions instead:
-        lib.exporters.modulesFromList  -> lib.exportModules
-        lib.exporters.fromOverlays     -> lib.exportPackages
-        lib.exporters.internalOverlays -> lib.exportOverlays
-    ''
-      {
-        modulesFromList = flake-utils-plus.lib.exportModules;
-        fromOverlays = flake-utils-plus.lib.exportPackages;
-        internalOverlays = flake-utils-plus.lib.exportOverlays;
-      }
-  ;
-
-  modules =
-    lib.warn ''
-      Deprecated Attribute Set: lib.modules.
-
-      Internal modules 'customBuilds', 'hmNixosDefaults' & 'globalDefaults'
-      will be completely removed from the api soon.
-
-      Please use digga.nixosModules for exported modules or proto-modules:
-        lib.modules.isoConfig -> nixosModules.boostrapIso
-    ''
-      (
-        internal-modules // { isoConfig = nixosModules.boostrapIso; }
-      )
-  ;
 
   importModules =
     lib.warn ''
@@ -96,26 +11,6 @@ rec {
 
       Use lib.importExportableModules instead to set `exportedModules` option
     ''
-      importers'.importExportableModules;
-
-  importers =
-    lib.warn ''
-      Deprecated Attribute Set: lib.importers.
-
-      Please use import* functions instead:
-        lib.importers.overlays    -> lib.importOverlays
-        lib.importers.modules     -> lib.importModules
-        lib.importers.hosts       -> lib.importHosts
-        lib.importers.rakeLeaves  -> lib.rakeLeaves
-        lib.importers.flattenTree -> lib.flattenTree
-    ''
-      {
-        overlays = importers'.importOverlays;
-        modules = importers'.importModules;
-        hosts = importers'.importHosts;
-        rakeLeaves = importers'.rakeLeaves;
-        flattenTree = importers'.flattenTree;
-      }
-  ;
+      importers.importExportableModules;
 
 }

--- a/flake.nix
+++ b/flake.nix
@@ -106,13 +106,7 @@
 
         # DEPRECATED - will be removed soon
         inherit (deprecated)
-          mkSuites
-          profileMap
-          mkProfileAttrs
-          exporters
-          modules
-          importModules
-          importers
+          # Place any deprecated lib functions here
           ;
 
       };

--- a/src/mkFlake/options.nix
+++ b/src/mkFlake/options.nix
@@ -297,44 +297,6 @@ let
     };
   };
 
-  suitesDeprecationMessage = ''
-    WARNING: The 'suites' and `profiles` options have been deprecated, you can now create
-    both with the importables option. `rakeLeaves` can be used to create profiles and
-    by passing a module or `rec` set to `importables`, suites can access profiles.
-    Example:
-    ```
-    importables = rec {
-      profiles = digga.lib.rakeLeaves ./profiles;
-      suites = with profiles; { };
-    }
-    ```
-    See https://github.com/divnix/digga/pull/30 for more details
-  '';
-  legacyImportablesMod = { config, options, ... }: {
-    config = {
-      importables = mkIf options.suites.isDefined {
-        suites = builtins.trace suitesDeprecationMessage config.suites;
-      };
-    };
-    options = with types; {
-      # TODO: remove in favor of importables
-      profiles = mkOption {
-        type = pathToOr legacyProfilesType;
-        default = [ ];
-        description = suitesDeprecationMessage;
-      };
-      # TODO: remove in favor of importables
-      suites = mkOption {
-        type = pathToOr legacySuitesType;
-        apply = suites: lib.mkSuites {
-          inherit suites;
-          inherit (config) profiles;
-        };
-        description = suitesDeprecationMessage;
-      };
-    };
-  };
-
   importablesOpt = {
     importables = mkOption {
       type = with types; submoduleWith {
@@ -390,7 +352,6 @@ let
     specialArgs = { inherit self inputs; };
     modules = [
       { options = (hostsOpt "nixos") // (hostDefaultsOpt "nixos") // importablesOpt; }
-      legacyImportablesMod
     ];
   };
 
@@ -399,7 +360,6 @@ let
     modules = [
       { options = regularModulesOpt // (exportedModulesOpt "home") // importablesOpt // usersOpt; }
       legacyExternalModulesMod
-      legacyImportablesMod
     ];
   };
 


### PR DESCRIPTION
I'm keeping the deprecation code for `externalModules` still, since there hasn't been a proper release that included that code.