### PR TITLE
fix: use gnu sed in shell tests for cross-platform compatibility

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -52,13 +52,13 @@ let
           git rm -f flake.lock
         fi
         # ensure: restore input
-        [ -z $diggaurl ] || sed -i "s|$tempdigga|$diggaurl|g" flake.nix
+        [ -z $diggaurl ] || ${pkgs.gnused}/bin/sed -i "s|$tempdigga|$diggaurl|g" flake.nix
       }
 
       digga_fixture() {
         # ensure: replace input
         diggaurl=$({ grep -o '"github:divnix/digga.*"' flake.nix || true; })
-        [ -z $diggaurl ] || sed -i "s|$diggaurl|$tempdigga|g" flake.nix
+        [ -z $diggaurl ] || ${pkgs.gnused}/bin/sed -i "s|$diggaurl|$tempdigga|g" flake.nix
       }
 
       trap_err() {


### PR DESCRIPTION
Darwin's use of BSD `sed` breaks here because BSD `sed` has a different
argument signature.

Spun off from #438 as suggested in https://github.com/divnix/digga/pull/438#discussion_r815551027