### PR TITLE
Set devshell subflake inputs to track parent flake inputs

### DIFF
--- a/devshell/flake.nix
+++ b/devshell/flake.nix
@@ -1,9 +1,18 @@
 {
   description = "Digga (formerly DevOS) devshell";
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-  inputs.devshell.url = "github:numtide/devshell";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.main.url = "path:../.";
+
+  inputs = {
+    # Parent flake
+    main.url = "path:../.";
+
+    # Inherited inputs
+    nixpkgs.follows = "main/nixpkgs";
+    devshell.follows = "main/devshell";
+
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
   outputs = inputs:
     inputs.flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin"] (
       system: let

--- a/devshell/flake.nix
+++ b/devshell/flake.nix
@@ -21,6 +21,7 @@
           main
           devshell
           nixpkgs
+          nixpkgs-unstable
           ;
         inherit
           (main.inputs.std.deSystemize system inputs.main.inputs)
@@ -99,9 +100,9 @@
               digga_fixture
 
               test -f flake.lock && lockfile_present=$? || true
-              ${nixpkgs.legacyPackages.nixUnstable}/bin/nix flake lock --update-input digga "$@"; lockfile_updated=$?;
-              ${nixpkgs.legacyPackages.nixUnstable}/bin/nix flake show "$@"
-              ${nixpkgs.legacyPackages.nixUnstable}/bin/nix flake check "$@"
+              ${nixpkgs-unstable.legacyPackages.nixUnstable}/bin/nix flake lock --update-input digga "$@"; lockfile_updated=$?;
+              ${nixpkgs-unstable.legacyPackages.nixUnstable}/bin/nix flake show "$@"
+              ${nixpkgs-unstable.legacyPackages.nixUnstable}/bin/nix flake check "$@"
 
               cleanup
             '';
@@ -124,7 +125,7 @@
             cellsFrom = "./nix";
             packages = [
               # formatters
-              nixpkgs.legacyPackages.alejandra
+              nixpkgs-unstable.legacyPackages.alejandra
               nixpkgs.legacyPackages.nodePackages.prettier
               nixpkgs.legacyPackages.shfmt
               nixpkgs.legacyPackages.editorconfig-checker

--- a/devshell/flake.nix
+++ b/devshell/flake.nix
@@ -100,7 +100,7 @@
       in {
         devShells.default = devshell.legacyPackages.mkShell (
           {extraModulesPath, ...}: {
-            name = "Digga (formerly DevOS)";
+            name = "digga-fka-devos";
 
             imports = [
               "${extraModulesPath}/git/hooks.nix"

--- a/flake.lock
+++ b/flake.lock
@@ -221,22 +221,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1647350163,
-        "narHash": "sha256-OcMI+PFEHTONthXuEQNddt16Ml7qGvanL3x8QOl2Aao=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3eb07eeafb52bcbf02ce800f032f18d666a9498d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "blank": "blank",
@@ -254,7 +238,9 @@
     },
     "std": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "yants": "yants"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       latest.url = "github:nixos/nixpkgs/nixos-unstable";
       nixlib.url = "github:nix-community/nixpkgs.lib";
       std.url = "github:divnix/std";
+      std.inputs.nixpkgs.follows = "nixpkgs";
       blank.url = "github:divnix/blank";
 
       deploy.url = "github:serokell/deploy-rs";


### PR DESCRIPTION
Addresses a few issues with the std input and devshell subflake I ran into on macOS while testing #438.

Depends on https://github.com/divnix/std/pull/47