### PR TITLE
ci: remove bors integration + use native github actions for pull request checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-      - trying
       - staging
+  pull_request:
 
 jobs:
   check:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/33905)
 [![MIT License](https://img.shields.io/github/license/divnix/devos)][mit]
 [![NixOS](https://img.shields.io/badge/NixOS-unstable-blue.svg?style=flat&logo=NixOS&logoColor=white)](https://nixos.org)
 [![Chat](https://img.shields.io/badge/chat-join%20us-brightgreen.svg?style=flat&logo=matrix&logoColor=white)](https://matrix.to/#/#devos:nixos.org)

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-status = [ "check" ]
-
-required_approvals = 1
-
-up_to_date_approvals = true
-
-delete_merged_branches = true

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # TL;DR;
 - **Target Branch**: `main`
-- **Merge Policy**: [`bors`][bors] is always right (&rarr; `bors try`)
+- **Merge Policy**: green check: merge away. yellow circle: have patience. red x: try again.
 - **Docs**: every change set is expected to contain doc updates
 - **Commit Msg**: be a poet! Comprehensive and explanatory commit messages 
   should cover the motivation and use case in an easily understandable manner
@@ -11,6 +11,4 @@
 ### Within the Devshell (`nix develop`)
 - **Hooks**: please `git commit` within the devshell
 - **Fail Early**: please run `check-all` from within the devshell on your local machine
-
-[bors]: https://bors.tech
 


### PR DESCRIPTION
- we've been having some problems with bors lately
- retrying a bors command notifies everyone watching the repo, which stinks when bors is behaving unexpectedly
- we really only make use of a very simple workflow which could be accomplished with GitHub Actions alone