### PR TITLE
ci updates + authenticated requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
 
     - uses: actions/checkout@v3
-      with:
-        submodules: true
-        fetch-depth: 0
 
     - uses: cachix/install-nix-action@v17
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-    - uses: cachix/install-nix-action@v16
+    - uses: cachix/install-nix-action@v17
       with:
         extra_nix_config: |
           system-features = nixos-test benchmark big-parallel kvm recursive-nix

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,7 @@ jobs:
     - uses: cachix/install-nix-action@v17
       with:
         extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
           system-features = nixos-test benchmark big-parallel kvm recursive-nix
           substituters = https://nrdxp.cachix.org https://nix-community.cachix.org https://cache.nixos.org
           trusted-public-keys = nrdxp.cachix.org-1:Fc5PSqY2Jm1TrWfm88l6cvGWwz3s93c6IOifQWnhNW4= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,10 +11,12 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+
     - uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0
+
     - uses: cachix/install-nix-action@v17
       with:
         extra_nix_config: |


### PR DESCRIPTION
I've been noticing some workflow runs are failing due to rate limiting. This should hopefully resolve those issues by following the example in https://github.com/cachix/install-nix-action#usage-with-flakes