### PR TITLE
458 Onboarding docs get you to a nix-shell

### DIFF
--- a/doc/start/index.md
+++ b/doc/start/index.md
@@ -19,9 +19,18 @@ git add .
 git commit -m init
 ```
 
-This will place you in a new folder named `devos` with git initialized, and a
-nix-shell that provides all the dependencies, including the unstable nix
-version required.
+To drop into a nix-shell, if you don't have flakes setup, use the digga shell to create a `flake.lock`:
+```sh
+nix-shell "https://github.com/divnix/digga/archive/main.tar.gz" \
+  --run "nix flake lock"
+```
+Or if you do have flakes support, just run:
+```sh
+nix flake lock
+```
+
+Finally, run `nix-shell` to get to an interactive shell with all the dependencies, including the unstable nix
+version required. You can run `menu` to confirm that you are using digga (expected output includes [docs], [general commands], [linter], etc.).
 
 In addition, the [binary cache](../integrations/cachix.md) is added for faster deployment.
 


### PR DESCRIPTION
Fixes #458

The command for users without flakes support is untested, I just modified the earlier `flake init` command using the digga shell