### PR TITLE
Fix shoulders of giants link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Digga is licensed under the [MIT License][mit].
 [examples]: https://github.com/divnix/digga/tree/main/examples
 [flakes]: https://nixos.wiki/wiki/Flakes
 [flake-utils-plus]: https://github.com/gytis-ivaskevicius/flake-utils-plus
+[giants]: https://en.wikipedia.org/wiki/Standing_on_the_shoulders_of_giants
 [home-manager]: https://github.com/nix-community/home-manager
 [issues]: https://github.com/divnix/digga/issues
 [mit]: https://mit-license.org


### PR DESCRIPTION
https://github.com/divnix/digga/pull/435 migrated the README to a new location, but didn't migrate this link.