### PR TITLE
hmOnly: track unstable channels

### DIFF
--- a/examples/hmOnly/flake.nix
+++ b/examples/hmOnly/flake.nix
@@ -1,22 +1,41 @@
 {
-  description = "A DevOS example. And also a digga test bed.";
+  description = "Example tracking unstable channels and libraries";
 
   inputs = {
-    nixos.url = "github:nixos/nixpkgs/nixos-22.05";
-    digga.url = "github:divnix/digga";
-    digga.inputs.nixpkgs.follows = "nixos";
-    digga.inputs.home-manager.follows = "home";
-    home.url = "github:nix-community/home-manager/release-22.05";
-    home.inputs.nixpkgs.follows = "nixos";
+    nixos-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixos-trunk.url = "github:NixOS/nixpkgs";
+    nixos-stable.url = "github:NixOS/nixpkgs/nixos-22.05";
+
+    digga.url = "github:divnix/digga/home-manager-22.11";
+    digga.inputs.nixpkgs.follows = "nixpkgs";
+    digga.inputs.nixlib.follows = "nixpkgs";
+    digga.inputs.home-manager.follows = "home-manager";
+
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixos-unstable";
+
+    nixpkgs.follows = "nixos-unstable";
   };
 
-  outputs = inputs @ { self, nixos, digga, home }:
+  outputs = {
+    self
+    , digga
+    , nixos-unstable
+    , home-manager
+    , nixpkgs
+    , ...
+  } @ inputs:
     digga.lib.mkFlake {
-
       inherit self inputs;
 
-      channels.nixos = { };
+      channels = {
+        nixos-unstable = {};
+        nixos-stable = {};
+        nixos-trunk = {};
+      };
 
+
+      # FIXME: should probably not be required, but it is.
       nixos.hostDefaults.channelName = "nixos";
 
       home = ./home;

--- a/examples/hmOnly/flake.nix
+++ b/examples/hmOnly/flake.nix
@@ -14,6 +14,9 @@
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixos-unstable";
 
+    emacs-overlay.url = "github:nix-community/emacs-overlay";
+    emacs-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
     nixpkgs.follows = "nixos-unstable";
   };
 
@@ -21,6 +24,7 @@
     self
     , digga
     , nixos-unstable
+    , emacs-overlay
     , home-manager
     , nixpkgs
     , ...
@@ -34,6 +38,9 @@
         nixos-trunk = {};
       };
 
+      sharedOverlays = [
+        emacs-overlay.overlay
+      ];
 
       # FIXME: should probably not be required, but it is.
       nixos.hostDefaults.channelName = "nixos";

--- a/examples/hmOnly/home/default.nix
+++ b/examples/hmOnly/home/default.nix
@@ -1,6 +1,6 @@
 { self, inputs, ... }:
 let
-  lib = inputs.digga.lib;
+  inherit (inputs.digga) lib;
 in
 {
   imports = [ (lib.importExportableModules ./modules) ];

--- a/examples/hmOnly/home/users/testuser.nix
+++ b/examples/hmOnly/home/users/testuser.nix
@@ -7,6 +7,8 @@ in
   imports = suites.shell;
 
   home.packages = with pkgs; [
+    # Provided by emacs-overlay
+    emacsPgtk
     # Python packages often fail to build on unstable channels.
     httpie
   ];
@@ -17,5 +19,14 @@ in
     userName = name;
     userEmail = email;
   };
+
+  programs.emacs = {
+    enable = true;
+    # While you'll probably want to use a native-comp package in the real world,
+    # in this example we want to avoid compilation to cut down on time/resources.
+    package = pkgs.emacsPgtk;
+  };
+
+  home.stateVersion = "22.11";
 }
 

--- a/examples/hmOnly/home/users/testuser.nix
+++ b/examples/hmOnly/home/users/testuser.nix
@@ -6,7 +6,10 @@ in
 {
   imports = suites.shell;
 
-  home.packages = [ pkgs.hello ];
+  home.packages = with pkgs; [
+    # Python packages often fail to build on unstable channels.
+    httpie
+  ];
 
   programs.browserpass.enable = true;
   programs.starship.enable = true;


### PR DESCRIPTION
- Verifies resolution of #464 
- Keeps track of unstable channels and releases of home-manager