### PR TITLE
`mkFlake`: limit nixosConfiguration flake check definitions to  hosts defined and managed by `digga`

### DIFF
--- a/src/mkFlake/outputs-builder.nix
+++ b/src/mkFlake/outputs-builder.nix
@@ -112,7 +112,11 @@ in
         (!pkgs.stdenv.buildPlatform.isDarwin)
       ) then
         let
-          hostConfigsOnThisSystem = collectors.collectHostsOnSystem self.nixosConfigurations system;
+          hostConfigsOnThisSystem =
+            let
+              configs = collectors.collectHostsOnSystem self.nixosConfigurations system;
+            in
+            lib.filterAttrs (n: v: lib.hasAttr n config.nixos.hosts) configs;
 
           createCustomTestOp = n: host: test:
             lib.warnIf (!(test ? name)) ''


### PR DESCRIPTION
I have a `digga`-managed flake where I do something like the following:

```nix
{
   inputs = { 
     # <snip>
   };

  outputs = { digga, ... }:
    let
      flake = digga.lib.mkFlake {
        # <snip>
      };

      extendedNixosConfigurations = lib.mapAttrs' (name: value: {
        name = "${name}-extended";
        value = value.extendModules {
          modules = [ 
            # <snip>
          ];
        };
      }) flake.nixosConfigurations;
    in 
    flake 
    // 
    {
      nixosConfigurations = flake.nixosConfigurations // extendedNixosConfigurations;
    };
}
```

Running `nix flake check`, I get this error:

```
error: attribute 'somehost-extended' missing

       at /nix/store/gyv51hksh3bngdqvafrwil6liskb57c1-source/src/mkFlake/outputs-builder.nix:131:42:

          130|             in
          131|             builtins.listToAttrs (map op config.nixos.hosts.${n}.tests);
             |                                          ^
          132|
```

This is because the `outputs-builder.nix` code that defines `nixosConfiguration`-related flake checks assumes that all entries in `nixosConfigurations` have corresponding entries in `config.nixos.hosts`.  This PR updates said code to define checks only for hosts that `digga` manages, filtering out whatever other hosts the user may have added to the `nixosConfigurations` flake output.

Thank you for your consideration!

---

Side note: am I just holding it wrong?  Maybe there's a more ergonomic way to extend previously-defined NixOS configurations -- perhaps something in the `mkFlake` interface that I've managed to overlook?  Would be cool if something like this were possible:

```nix
{
  flake = digga.lib.mkFlake {
    # <snip>

    extend = final: prev: {
      nixosConfigurations = prev.nixosConfigurations // lib.mapAttrs' (name: value: {
        name = "${name}-extended";
        value = value.extendModules {
          modules = [ 
            # <snip>
          ];
        };
      }) prev.nixosConfigurations;
    };
  };
}
```