### PR TITLE
Add another example repo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can also see digga being actually used:
 * [@danielphan2003](https://github.com/danielphan2003/flk) and make sure to also check out [devos-ext-lib](https://github.com/divnix/devos-ext-lib)
 * [PubSolarOS](https://git.sr.ht/~b12f/pub-solar-os)
 * @montchr: [Dotfield](https://github.com/montchr/dotfield) – including darwin configurations
+* [@sweenu](https://github.com/sweenu/nixfiles): pc, server and RaspberryPi deployment in one repo
 
 
 # Philosophy


### PR DESCRIPTION
Hello!

I propose adding my repo as another example repo in the README.
The interesting stuff would be the fact that I mix my home-manager configs with my system configs and maybe the RaspberryPi deployment.

I won't feel bad if you reject the PR ;)