### PR TITLE
Devos Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 result
 .direnv
+examples/**/flake.lock

--- a/examples/devos/flake.nix
+++ b/examples/devos/flake.nix
@@ -7,6 +7,11 @@
 
   inputs =
     {
+      flake-compat = {
+        url = "github:edolstra/flake-compat";
+        flake = false;
+      };
+      
       # Track channels with commits tested and built by hydra
       nixos.url = "github:nixos/nixpkgs/nixos-22.05";
       latest.url = "github:nixos/nixpkgs/nixos-unstable";

--- a/examples/devos/lib/compat/default.nix
+++ b/examples/devos/lib/compat/default.nix
@@ -1,14 +1,14 @@
 let
-  rev = "e7e5d481a0e15dcd459396e55327749989e04ce0";
+  lock = builtins.fromJSON (builtins.readFile builtins.path { path = ../../flake.lock; name = "lockPath"; });
   flake = (import
     (
       fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${rev}.tar.gz";
-        sha256 = "0zd3x46fswh5n6faq4x2kkpy6p3c6j593xbdlbsl40ppkclwc80x";
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
       }
     )
     {
-      src = ../../.;
+      src = builtins.path { path = ../../.; name = "projectRoot"; };
     });
 in
 flake

--- a/examples/devos/shell/devos.nix
+++ b/examples/devos/shell/devos.nix
@@ -25,21 +25,6 @@ in
   imports = [ "${extraModulesPath}/git/hooks.nix" ];
   git = { inherit hooks; };
 
-  # tempfix: remove when merged https://github.com/numtide/devshell/pull/123
-  devshell.startup.load_profiles = pkgs.lib.mkForce (pkgs.lib.noDepEntry ''
-    # PATH is devshell's exorbitant privilige:
-    # fence against its pollution
-    _PATH=''${PATH}
-    # Load installed profiles
-    for file in "$DEVSHELL_DIR/etc/profile.d/"*.sh; do
-      # If that folder doesn't exist, bash loves to return the whole glob
-      [[ -f "$file" ]] && source "$file"
-    done
-    # Exert exorbitant privilige and leave no trace
-    export PATH=''${_PATH}
-    unset _PATH
-  '');
-
   commands = [
     (devos nixUnstable)
     (devos agenix)

--- a/examples/devos/shell/hooks/pre-commit.sh
+++ b/examples/devos/shell/hooks/pre-commit.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-if git rev-parse --verify HEAD >/dev/null 2>&1
-then
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
   against=HEAD
 else
   # Initial commit: diff against an empty tree object
@@ -14,19 +13,17 @@ nix_files=($($diff -- '*.nix'))
 all_files=($($diff))
 
 # Format staged nix files.
-if (( ${#nix_files[@]} != 0 )); then
-  nixpkgs-fmt "${nix_files[@]}" \
-  && git add "${nix_files[@]}"
+if ((${#nix_files[@]} != 0)); then
+  nixpkgs-fmt "${nix_files[@]}" &&
+    git add "${nix_files[@]}"
 fi
 
 # check editorconfig
-if (( ${#all_files[@]} != 0 )); then
-  editorconfig-checker -- "${all_files[@]}"
-fi
-
-if [[ $? != '0' ]]; then
-  printf "%b\n" \
-    "\nCode is not aligned with .editorconfig" \
-    "Review the output and commit your fixes" >&2
-  exit 1
+if ((${#all_files[@]} != 0)); then
+  if ! editorconfig-checker -- "${all_files[@]}"; then
+    printf "%b\n" \
+      "\nCode is not aligned with .editorconfig" \
+      "Review the output and commit your fixes" >&2
+    exit 1
+  fi
 fi


### PR DESCRIPTION
I unpinned flake-compat, favouring whatever rev is put in the lock file instead and checked the `editorconfig-checker` exit code directly, [avoiding potential issues](https://github.com/koalaman/shellcheck/wiki/SC2181). The issue causing the tempfix [has been resolved](https://github.com/numtide/devshell/issues/26).