### PR TITLE
Update home-manager to 22.11

### DIFF
--- a/examples/devos/flake.lock
+++ b/examples/devos/flake.lock
@@ -271,19 +271,20 @@
       "inputs": {
         "nixpkgs": [
           "nixos"
-        ]
+        ],
+        "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1667907331,
-        "narHash": "sha256-bHkAwkYlBjkupPUFcQjimNS8gxWSWjOTevEuwdnp5m0=",
+        "lastModified": 1672244468,
+        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6639e3a837fc5deb6f99554072789724997bc8e5",
+        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.05",
+        "ref": "release-22.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -434,6 +435,21 @@
       }
     },
     "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",

--- a/examples/devos/flake.nix
+++ b/examples/devos/flake.nix
@@ -36,7 +36,7 @@
     digga.inputs.home-manager.follows = "home";
     digga.inputs.deploy.follows = "deploy";
 
-    home.url = "github:nix-community/home-manager/release-22.05";
+    home.url = "github:nix-community/home-manager/release-22.11";
     home.inputs.nixpkgs.follows = "nixos";
 
     darwin.url = "github:LnL7/nix-darwin";
@@ -196,8 +196,16 @@
           # it could just be left to the developer to determine what's
           # appropriate. after all, configuring these hm users is one of the
           # first steps in customizing the template.
-          nixos = {suites, ...}: {imports = suites.base;};
-          darwin = {suites, ...}: {imports = suites.base;};
+          nixos = {suites, ...}: {
+            imports = suites.base;
+
+            home.stateVersion = "22.11";
+          };
+          darwin = {suites, ...}: {
+            imports = suites.base;
+
+            home.stateVersion = "22.11";
+          };
         }; # digga.lib.importers.rakeLeaves ./users/hm;
       };
 

--- a/examples/groupByConfig/flake.lock
+++ b/examples/groupByConfig/flake.lock
@@ -199,19 +199,20 @@
       "inputs": {
         "nixpkgs": [
           "nixos"
-        ]
+        ],
+        "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1667907331,
-        "narHash": "sha256-bHkAwkYlBjkupPUFcQjimNS8gxWSWjOTevEuwdnp5m0=",
+        "lastModified": 1672244468,
+        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6639e3a837fc5deb6f99554072789724997bc8e5",
+        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.05",
+        "ref": "release-22.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -331,6 +332,21 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {

--- a/examples/groupByConfig/flake.nix
+++ b/examples/groupByConfig/flake.nix
@@ -19,7 +19,7 @@
     darwin.url = "github:LnL7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs-darwin-stable";
 
-    home.url = "github:nix-community/home-manager/release-22.05";
+    home.url = "github:nix-community/home-manager/release-22.11";
     home.inputs.nixpkgs.follows = "nixos";
   };
 

--- a/examples/hmOnly/flake.lock
+++ b/examples/hmOnly/flake.lock
@@ -181,19 +181,20 @@
       "inputs": {
         "nixpkgs": [
           "nixos"
-        ]
+        ],
+        "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1667907331,
-        "narHash": "sha256-bHkAwkYlBjkupPUFcQjimNS8gxWSWjOTevEuwdnp5m0=",
+        "lastModified": 1672244468,
+        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6639e3a837fc5deb6f99554072789724997bc8e5",
+        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.05",
+        "ref": "release-22.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -259,6 +260,21 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {

--- a/examples/hmOnly/flake.nix
+++ b/examples/hmOnly/flake.nix
@@ -6,7 +6,7 @@
     digga.url = "github:divnix/digga";
     digga.inputs.nixpkgs.follows = "nixos";
     digga.inputs.home-manager.follows = "home";
-    home.url = "github:nix-community/home-manager/release-22.05";
+    home.url = "github:nix-community/home-manager/release-22.11";
     home.inputs.nixpkgs.follows = "nixos";
   };
 

--- a/examples/hmOnly/home/users/testuser.nix
+++ b/examples/hmOnly/home/users/testuser.nix
@@ -8,7 +8,10 @@
 in {
   imports = suites.shell;
 
-  home.packages = [pkgs.hello];
+  home = {
+    packages = [pkgs.hello];
+    stateVersion = "22.11";
+  };
 
   programs.browserpass.enable = true;
   programs.starship.enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -150,19 +150,22 @@
       "inputs": {
         "nixpkgs": [
           "nixlib"
+        ],
+        "utils": [
+          "flake-utils"
         ]
       },
       "locked": {
-        "lastModified": 1667907331,
-        "narHash": "sha256-bHkAwkYlBjkupPUFcQjimNS8gxWSWjOTevEuwdnp5m0=",
+        "lastModified": 1672244468,
+        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6639e3a837fc5deb6f99554072789724997bc8e5",
+        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.05",
+        "ref": "release-22.11",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,9 @@
     deploy.url = "github:serokell/deploy-rs";
     deploy.inputs.nixpkgs.follows = "nixpkgs";
 
-    home-manager.url = "github:nix-community/home-manager/release-22.05";
+    home-manager.url = "github:nix-community/home-manager/release-22.11";
     home-manager.inputs.nixpkgs.follows = "nixlib";
+    home-manager.inputs.utils.follows = "flake-utils";
 
     darwin.url = "github:LnL7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs";

--- a/src/mkFlake/outputs-builder.nix
+++ b/src/mkFlake/outputs-builder.nix
@@ -27,20 +27,27 @@
     homeDirectory = "${homeDirectoryPrefix}/${username}";
   in
     home-manager.lib.homeManagerConfiguration {
-      inherit username homeDirectory pkgs system;
+      inherit pkgs;
 
-      extraModules = config.home.modules ++ config.home.exportedModules;
+      modules =
+        config.home.modules
+        ++ config.home.exportedModules
+        ++ [
+          ({
+              imports = [configuration];
+
+              home = {
+                inherit username homeDirectory;
+              };
+            }
+            // (
+              if (pkgs.stdenv.hostPlatform.isLinux && !pkgs.stdenv.buildPlatform.isDarwin)
+              then {targets.genericLinux.enable = true;}
+              else {}
+            ))
+        ];
+
       extraSpecialArgs = config.home.importables // {inherit self inputs;};
-
-      configuration =
-        {
-          imports = [configuration];
-        }
-        // (
-          if (pkgs.stdenv.hostPlatform.isLinux && !pkgs.stdenv.buildPlatform.isDarwin)
-          then {targets.genericLinux.enable = true;}
-          else {}
-        );
     };
 
   homeConfigurationsPortable =


### PR DESCRIPTION
This commit updates the home-manager flake input to the 22.11 release and creates additional support for the new homeManagerConfiguration setup that is introduced there.

~The new release of home-manager introduces a dependency to numtide/flake-utils, which already exists in deploy-rs. To reduce the amount of different versions, this commit makes the input of deploy-rs follow the respective one of home-manager.~ (see my comment below on why I dropped this)

Regarding homeManagerConfiguration, some arguments that were previously in use, now need to be used inside the new modules argument (check [here][hm-22.11-highlights] for more details).

The stateVersion is additionally explicitly defined to be the same as the home-manager's release version, so that existing configurations do not break when they upgrade their home-manager flake input.

[hm-22.11-highlights]: https://nix-community.github.io/home-manager/release-notes.html#sec-release-22.11-highlights