### PR TITLE
:pencil: devos: clarify how to use /lib/

### DIFF
--- a/examples/devos/lib/default.nix
+++ b/examples/devos/lib/default.nix
@@ -1,2 +1,12 @@
 {lib}:
-lib.makeExtensible (self: {})
+lib.makeExtensible (self:
+let
+  callLibs = file: import file { lib = self; };
+in
+rec {
+  ## Define your own library functions here!
+  #id = x: x;
+  ## Or in files, containing functions that take {lib}
+  #foo = callLibs ./foo.nix;
+  ## In configs, they can be used under "lib.our"
+})


### PR DESCRIPTION
Hi all. I wanted to put custom functions in the /lib/ directory, but lib/default.nix was basically empty and I couldn't find anything in the docs about it. After a while I figured it out, and I thought it would help future noobs if there was a note in the file explaining itself.

Thanks for the great template!